### PR TITLE
Add tests for NodeOAuthClientProvider functionality

### DIFF
--- a/tests/node-oauth-client-provider_test.ts
+++ b/tests/node-oauth-client-provider_test.ts
@@ -1,15 +1,17 @@
-import { assertEquals, assertRejects } from "std/assert/mod.ts";
+import {
+  assert,
+  assertEquals,
+  assertMatch,
+  assertRejects,
+} from "std/assert/mod.ts";
 import { afterEach, beforeEach, describe, it } from "std/testing/bdd.ts";
 import {
   assertSpyCallArg,
   assertSpyCalls,
   spy,
-  stub,
 } from "std/testing/mock.ts";
+import type { Spy } from "std/testing/mock.ts";
 import { NodeOAuthClientProvider } from "../src/lib/node-oauth-client-provider.ts";
-import * as mcpAuth from "../src/lib/mcp-auth-config.ts";
-import * as utils from "../src/lib/utils.ts";
-import openModule from "../src/lib/deno-open.ts";
 import {
   OAuthClientInformationSchema,
   OAuthTokensSchema,
@@ -18,16 +20,14 @@ import type {
   OAuthClientInformationFull,
   OAuthTokens,
 } from "@modelcontextprotocol/sdk/shared/auth.js";
+import type * as McpAuthTypes from "../src/lib/mcp-auth-config.ts";
+import type * as UtilsTypes from "../src/lib/utils.ts";
+import type * as OpenModuleTypes from "../src/lib/deno-open.ts";
+import type { NodeOAuthClientProviderDeps } from "../src/lib/node-oauth-client-provider.ts"; // Import deps interface
 
-// Helper function to check if a string contains a substring
-function stringContaining(expected: string) {
-  return {
-    asymmetricMatch: (actual: string) => {
-      return typeof actual === "string" && actual.includes(expected);
-    },
-    toString: () => `StringContaining(${expected})`,
-  };
-}
+// Define types for mock functions for better type safety
+// deno-lint-ignore no-explicit-any
+type MockFn<T extends (...args: any[]) => any> = Spy<T>;
 
 describe("NodeOAuthClientProvider", () => {
   const testServerUrl = "https://test-server.example.com";
@@ -43,91 +43,98 @@ describe("NodeOAuthClientProvider", () => {
     softwareVersion: "1.0.0",
   };
 
+  // Declare mock functions with specific types
+  let mockGetServerUrlHash: MockFn<typeof UtilsTypes.getServerUrlHash>;
+  let mockReadJsonFile: MockFn<typeof McpAuthTypes.readJsonFile>;
+  let mockWriteJsonFile: MockFn<typeof McpAuthTypes.writeJsonFile>;
+  let mockReadTextFile: MockFn<typeof McpAuthTypes.readTextFile>;
+  let mockWriteTextFile: MockFn<typeof McpAuthTypes.writeTextFile>;
+  let mockLog: MockFn<typeof UtilsTypes.log>;
+  let mockOpen: MockFn<typeof OpenModuleTypes.default>;
+  let mockDeps: NodeOAuthClientProviderDeps; // Use the imported interface
+
   beforeEach(() => {
+    // Reset mocks before each test
+    mockGetServerUrlHash = spy(() => testServerUrlHash);
+    const basicReadJsonMock = spy(() => Promise.resolve(undefined));
+    mockReadJsonFile = basicReadJsonMock as unknown as MockFn<
+      typeof McpAuthTypes.readJsonFile
+    >;
+    mockWriteJsonFile = spy(() => Promise.resolve());
+    mockReadTextFile = spy(() => Promise.reject(new Error("File not found")));
+    mockWriteTextFile = spy(() => Promise.resolve());
+    mockLog = spy();
+    mockOpen = spy(() => Promise.resolve());
+
+    // Group mocks into the deps object for injection
+    mockDeps = {
+      getServerUrlHash: mockGetServerUrlHash,
+      readJsonFile: mockReadJsonFile,
+      writeJsonFile: mockWriteJsonFile,
+      readTextFile: mockReadTextFile,
+      writeTextFile: mockWriteTextFile,
+      log: mockLog,
+      open: mockOpen,
+      mcpRemoteVersion: "test-version", // Provide a test version
+    };
     // Add any setup needed for each test
   });
 
   afterEach(() => {
+    // Restore any stubs after each test to avoid interference
+    // This assumes stub instances are accessible or managed globally/contextually
+    // For simplicity, let's re-stub in each test and restore there if needed, or manage stubs better.
+    // If stubs are created within `it` blocks, they should be restored there.
     // Clean up after each test
   });
 
   describe("constructor", () => {
     it("initializes with provided options", () => {
-      const getServerUrlHashStub = stub(
-        utils,
-        "getServerUrlHash",
-        () => testServerUrlHash,
-      );
-
-      const provider = new NodeOAuthClientProvider(testOptions);
+      const provider = new NodeOAuthClientProvider(testOptions, mockDeps);
 
       assertEquals(provider.options, testOptions);
-      assertSpyCalls(getServerUrlHashStub, 1);
-      assertSpyCallArg(getServerUrlHashStub, 0, 0, testServerUrl);
-
-      getServerUrlHashStub.restore();
+      // Check if getServerUrlHash was called during construction
+      assertSpyCalls(mockGetServerUrlHash, 1);
+      assertSpyCallArg(mockGetServerUrlHash, 0, 0, testServerUrl);
     });
 
     it("uses default values for optional parameters", () => {
-      const getServerUrlHashStub = stub(
-        utils,
-        "getServerUrlHash",
-        () => testServerUrlHash,
-      );
-
       const provider = new NodeOAuthClientProvider({
         serverUrl: testServerUrl,
         callbackPort: testCallbackPort,
-      });
+      }, mockDeps);
 
       assertEquals(provider.options.serverUrl, testServerUrl);
       assertEquals(provider.options.callbackPort, testCallbackPort);
-      // biome-ignore lint/complexity/useLiteralKeys: accessing private property for testing
       assertEquals(provider["callbackPath"], "/oauth/callback"); // Default value
-      // biome-ignore lint/complexity/useLiteralKeys: accessing private property for testing
       assertEquals(provider["clientName"], "MCP CLI Client"); // Default value
-      // biome-ignore lint/complexity/useLiteralKeys: accessing private property for testing
       assertEquals(
         provider["clientUri"],
         "https://github.com/modelcontextprotocol/mcp-cli",
       ); // Default value
-      // biome-ignore lint/complexity/useLiteralKeys: accessing private property for testing
       assertEquals(
         provider["softwareId"],
         "2e6dc280-f3c3-4e01-99a7-8181dbd1d23d",
       ); // Default value
-      // biome-ignore lint/complexity/useLiteralKeys: accessing private property for testing
-      assertEquals(provider["softwareVersion"], utils.MCP_REMOTE_VERSION); // Default value
-
-      getServerUrlHashStub.restore();
+      assertEquals(
+        provider.clientMetadata.software_version,
+        mockDeps.mcpRemoteVersion,
+      );
     });
   });
 
   describe("getters", () => {
     it("returns correct redirectUrl", () => {
-      const getServerUrlHashStub = stub(
-        utils,
-        "getServerUrlHash",
-        () => testServerUrlHash,
-      );
-
-      const provider = new NodeOAuthClientProvider(testOptions);
+      const provider = new NodeOAuthClientProvider(testOptions, mockDeps);
       assertEquals(
         provider.redirectUrl,
         `http://127.0.0.1:${testCallbackPort}${testOptions.callbackPath}`,
       );
-
-      getServerUrlHashStub.restore();
+      assertSpyCalls(mockGetServerUrlHash, 1); // Called in constructor
     });
 
     it("returns correct clientMetadata", () => {
-      const getServerUrlHashStub = stub(
-        utils,
-        "getServerUrlHash",
-        () => testServerUrlHash,
-      );
-
-      const provider = new NodeOAuthClientProvider(testOptions);
+      const provider = new NodeOAuthClientProvider(testOptions, mockDeps);
 
       const expectedMetadata = {
         redirect_uris: [
@@ -143,8 +150,7 @@ describe("NodeOAuthClientProvider", () => {
       };
 
       assertEquals(provider.clientMetadata, expectedMetadata);
-
-      getServerUrlHashStub.restore();
+      assertSpyCalls(mockGetServerUrlHash, 1);
     });
   });
 
@@ -155,50 +161,44 @@ describe("NodeOAuthClientProvider", () => {
         redirect_uris: ["http://localhost:3000/callback"],
       };
 
-      const getServerUrlHashStub = stub(
-        utils,
-        "getServerUrlHash",
-        () => testServerUrlHash,
+      // Set up mock return value for this test case
+      const specificReadJsonMockClient = spy(() =>
+        Promise.resolve(mockClientInfo)
       );
-      const readJsonFileStub = stub(
-        mcpAuth,
-        "readJsonFile",
-        () => Promise.resolve(mockClientInfo),
-      );
+      mockReadJsonFile = specificReadJsonMockClient as unknown as MockFn<
+        typeof McpAuthTypes.readJsonFile
+      >;
+      mockDeps.readJsonFile = mockReadJsonFile;
 
-      const provider = new NodeOAuthClientProvider(testOptions);
+      const provider = new NodeOAuthClientProvider(testOptions, mockDeps);
       const result = await provider.clientInformation();
 
       assertEquals(result, mockClientInfo);
-      assertSpyCalls(readJsonFileStub, 1);
-      assertSpyCallArg(readJsonFileStub, 0, 0, testServerUrlHash);
-      assertSpyCallArg(readJsonFileStub, 0, 1, "client_info.json");
-      assertSpyCallArg(readJsonFileStub, 0, 2, OAuthClientInformationSchema);
+      assertSpyCalls(mockReadJsonFile, 1);
+      assertSpyCallArg(mockReadJsonFile, 0, 0, testServerUrlHash);
+      assertSpyCallArg(mockReadJsonFile, 0, 1, "client_info.json");
+      assertSpyCallArg(mockReadJsonFile, 0, 2, OAuthClientInformationSchema);
 
-      getServerUrlHashStub.restore();
-      readJsonFileStub.restore();
+      // Check constructor call too
+      assertSpyCalls(mockGetServerUrlHash, 1);
     });
 
     it("returns undefined when client information doesn't exist", async () => {
-      const getServerUrlHashStub = stub(
-        utils,
-        "getServerUrlHash",
-        () => testServerUrlHash,
-      );
-      const readJsonFileStub = stub(
-        mcpAuth,
-        "readJsonFile",
-        () => Promise.resolve(undefined),
-      );
+      // Default mockReadJsonFile returns undefined, so no need to reset it
+      const specificReadJsonMockUndef = spy(() => Promise.resolve(undefined));
+      mockReadJsonFile = specificReadJsonMockUndef as unknown as MockFn<
+        typeof McpAuthTypes.readJsonFile
+      >;
+      mockDeps.readJsonFile = mockReadJsonFile;
 
-      const provider = new NodeOAuthClientProvider(testOptions);
+      const provider = new NodeOAuthClientProvider(testOptions, mockDeps);
       const result = await provider.clientInformation();
 
       assertEquals(result, undefined);
-      assertSpyCalls(readJsonFileStub, 1);
+      assertSpyCalls(mockReadJsonFile, 1);
 
-      getServerUrlHashStub.restore();
-      readJsonFileStub.restore();
+      // Check constructor call too
+      assertSpyCalls(mockGetServerUrlHash, 1);
     });
   });
 
@@ -212,27 +212,16 @@ describe("NodeOAuthClientProvider", () => {
         client_secret_expires_at: 0,
       };
 
-      const getServerUrlHashStub = stub(
-        utils,
-        "getServerUrlHash",
-        () => testServerUrlHash,
-      );
-      const writeJsonFileStub = stub(
-        mcpAuth,
-        "writeJsonFile",
-        () => Promise.resolve(),
-      );
-
-      const provider = new NodeOAuthClientProvider(testOptions);
+      const provider = new NodeOAuthClientProvider(testOptions, mockDeps);
       await provider.saveClientInformation(mockClientInfo);
 
-      assertSpyCalls(writeJsonFileStub, 1);
-      assertSpyCallArg(writeJsonFileStub, 0, 0, testServerUrlHash);
-      assertSpyCallArg(writeJsonFileStub, 0, 1, "client_info.json");
-      assertSpyCallArg(writeJsonFileStub, 0, 2, mockClientInfo);
+      assertSpyCalls(mockWriteJsonFile, 1);
+      assertSpyCallArg(mockWriteJsonFile, 0, 0, testServerUrlHash);
+      assertSpyCallArg(mockWriteJsonFile, 0, 1, "client_info.json");
+      assertSpyCallArg(mockWriteJsonFile, 0, 2, mockClientInfo);
 
-      getServerUrlHashStub.restore();
-      writeJsonFileStub.restore();
+      // Check constructor call too
+      assertSpyCalls(mockGetServerUrlHash, 1);
     });
   });
 
@@ -245,50 +234,42 @@ describe("NodeOAuthClientProvider", () => {
         expires_in: 3600,
       };
 
-      const getServerUrlHashStub = stub(
-        utils,
-        "getServerUrlHash",
-        () => testServerUrlHash,
-      );
-      const readJsonFileStub = stub(
-        mcpAuth,
-        "readJsonFile",
-        () => Promise.resolve(mockTokens),
-      );
+      // Set up mock return value for this test case
+      const specificReadJsonMockTokens = spy(() => Promise.resolve(mockTokens));
+      mockReadJsonFile = specificReadJsonMockTokens as unknown as MockFn<
+        typeof McpAuthTypes.readJsonFile
+      >;
+      mockDeps.readJsonFile = mockReadJsonFile;
 
-      const provider = new NodeOAuthClientProvider(testOptions);
+      const provider = new NodeOAuthClientProvider(testOptions, mockDeps);
       const result = await provider.tokens();
 
       assertEquals(result, mockTokens);
-      assertSpyCalls(readJsonFileStub, 1);
-      assertSpyCallArg(readJsonFileStub, 0, 0, testServerUrlHash);
-      assertSpyCallArg(readJsonFileStub, 0, 1, "tokens.json");
-      assertSpyCallArg(readJsonFileStub, 0, 2, OAuthTokensSchema);
+      assertSpyCalls(mockReadJsonFile, 1);
+      assertSpyCallArg(mockReadJsonFile, 0, 0, testServerUrlHash);
+      assertSpyCallArg(mockReadJsonFile, 0, 1, "tokens.json");
+      assertSpyCallArg(mockReadJsonFile, 0, 2, OAuthTokensSchema);
 
-      getServerUrlHashStub.restore();
-      readJsonFileStub.restore();
+      // Check constructor call too
+      assertSpyCalls(mockGetServerUrlHash, 1);
     });
 
     it("returns undefined when tokens don't exist", async () => {
-      const getServerUrlHashStub = stub(
-        utils,
-        "getServerUrlHash",
-        () => testServerUrlHash,
-      );
-      const readJsonFileStub = stub(
-        mcpAuth,
-        "readJsonFile",
-        () => Promise.resolve(undefined),
-      );
+      // Default mockReadJsonFile returns undefined
+      const specificReadJsonMockUndef2 = spy(() => Promise.resolve(undefined));
+      mockReadJsonFile = specificReadJsonMockUndef2 as unknown as MockFn<
+        typeof McpAuthTypes.readJsonFile
+      >;
+      mockDeps.readJsonFile = mockReadJsonFile;
 
-      const provider = new NodeOAuthClientProvider(testOptions);
+      const provider = new NodeOAuthClientProvider(testOptions, mockDeps);
       const result = await provider.tokens();
 
       assertEquals(result, undefined);
-      assertSpyCalls(readJsonFileStub, 1);
+      assertSpyCalls(mockReadJsonFile, 1);
 
-      getServerUrlHashStub.restore();
-      readJsonFileStub.restore();
+      // Check constructor call too
+      assertSpyCalls(mockGetServerUrlHash, 1);
     });
   });
 
@@ -301,27 +282,16 @@ describe("NodeOAuthClientProvider", () => {
         expires_in: 3600,
       };
 
-      const getServerUrlHashStub = stub(
-        utils,
-        "getServerUrlHash",
-        () => testServerUrlHash,
-      );
-      const writeJsonFileStub = stub(
-        mcpAuth,
-        "writeJsonFile",
-        () => Promise.resolve(),
-      );
-
-      const provider = new NodeOAuthClientProvider(testOptions);
+      const provider = new NodeOAuthClientProvider(testOptions, mockDeps);
       await provider.saveTokens(mockTokens);
 
-      assertSpyCalls(writeJsonFileStub, 1);
-      assertSpyCallArg(writeJsonFileStub, 0, 0, testServerUrlHash);
-      assertSpyCallArg(writeJsonFileStub, 0, 1, "tokens.json");
-      assertSpyCallArg(writeJsonFileStub, 0, 2, mockTokens);
+      assertSpyCalls(mockWriteJsonFile, 1);
+      assertSpyCallArg(mockWriteJsonFile, 0, 0, testServerUrlHash);
+      assertSpyCallArg(mockWriteJsonFile, 0, 1, "tokens.json");
+      assertSpyCallArg(mockWriteJsonFile, 0, 2, mockTokens);
 
-      getServerUrlHashStub.restore();
-      writeJsonFileStub.restore();
+      // Check constructor call too
+      assertSpyCalls(mockGetServerUrlHash, 1);
     });
   });
 
@@ -331,36 +301,26 @@ describe("NodeOAuthClientProvider", () => {
         "https://auth.example.com/authorize?client_id=test",
       );
 
-      const getServerUrlHashStub = stub(
-        utils,
-        "getServerUrlHash",
-        () => testServerUrlHash,
-      );
-      const logSpy = spy(utils, "log");
-      const openStub = stub(
-        openModule,
-        "default" as keyof typeof openModule,
-        () => Promise.resolve(),
-      );
-
-      const provider = new NodeOAuthClientProvider(testOptions);
+      const provider = new NodeOAuthClientProvider(testOptions, mockDeps);
       await provider.redirectToAuthorization(authUrl);
 
-      assertSpyCalls(logSpy, 2);
-      assertSpyCallArg(
-        logSpy,
-        0,
-        0,
-        stringContaining("Please authorize this client by visiting:"),
+      // Should log twice: the URL and the success message
+      assertSpyCalls(mockLog, 2);
+      // Manually check the first log call's argument
+      const firstCallArgsSuccess = mockLog.calls[0].args;
+      assert(typeof firstCallArgsSuccess[0] === "string");
+      assertMatch(
+        firstCallArgsSuccess[0],
+        /Please authorize this client by visiting:/,
       );
-      assertSpyCallArg(logSpy, 1, 0, "Browser opened automatically.");
+      assertSpyCallArg(mockLog, 1, 0, "Browser opened automatically.");
 
-      assertSpyCalls(openStub, 1);
-      assertSpyCallArg(openStub, 0, 0, authUrl.toString());
+      // Check if open was called
+      assertSpyCalls(mockOpen, 1);
+      assertSpyCallArg(mockOpen, 0, 0, authUrl.toString());
 
-      getServerUrlHashStub.restore();
-      logSpy.restore();
-      openStub.restore();
+      // Check constructor call too
+      assertSpyCalls(mockGetServerUrlHash, 1);
     });
 
     it("logs a fallback message when browser can't be opened", async () => {
@@ -368,42 +328,34 @@ describe("NodeOAuthClientProvider", () => {
         "https://auth.example.com/authorize?client_id=test",
       );
 
-      const getServerUrlHashStub = stub(
-        utils,
-        "getServerUrlHash",
-        () => testServerUrlHash,
-      );
-      const logSpy = spy(utils, "log");
-      const openStub = stub(
-        openModule,
-        "default" as keyof typeof openModule,
-        () => {
-          throw new Error("Failed to open browser");
-        },
-      );
+      // Make the mock open function throw an error
+      mockOpen = spy(() => Promise.reject(new Error("Failed to open browser")));
+      mockDeps.open = mockOpen;
 
-      const provider = new NodeOAuthClientProvider(testOptions);
+      const provider = new NodeOAuthClientProvider(testOptions, mockDeps);
       await provider.redirectToAuthorization(authUrl);
 
-      assertSpyCalls(logSpy, 2);
-      assertSpyCallArg(
-        logSpy,
-        0,
-        0,
-        stringContaining("Please authorize this client by visiting:"),
+      // Should log twice: the URL and the fallback message
+      assertSpyCalls(mockLog, 2);
+      // Manually check the first log call's argument
+      const firstCallArgsFallback = mockLog.calls[0].args;
+      assert(typeof firstCallArgsFallback[0] === "string");
+      assertMatch(
+        firstCallArgsFallback[0],
+        /Please authorize this client by visiting:/,
       );
       assertSpyCallArg(
-        logSpy,
+        mockLog,
         1,
         0,
         "Could not open browser automatically. Please copy and paste the URL above into your browser.",
       );
 
-      assertSpyCalls(openStub, 1);
+      // Check if open was called (and failed)
+      assertSpyCalls(mockOpen, 1);
 
-      getServerUrlHashStub.restore();
-      logSpy.restore();
-      openStub.restore();
+      // Check constructor call too
+      assertSpyCalls(mockGetServerUrlHash, 1);
     });
   });
 
@@ -411,27 +363,16 @@ describe("NodeOAuthClientProvider", () => {
     it("saves the code verifier", async () => {
       const codeVerifier = "test-code-verifier";
 
-      const getServerUrlHashStub = stub(
-        utils,
-        "getServerUrlHash",
-        () => testServerUrlHash,
-      );
-      const writeTextFileStub = stub(
-        mcpAuth,
-        "writeTextFile",
-        () => Promise.resolve(),
-      );
-
-      const provider = new NodeOAuthClientProvider(testOptions);
+      const provider = new NodeOAuthClientProvider(testOptions, mockDeps);
       await provider.saveCodeVerifier(codeVerifier);
 
-      assertSpyCalls(writeTextFileStub, 1);
-      assertSpyCallArg(writeTextFileStub, 0, 0, testServerUrlHash);
-      assertSpyCallArg(writeTextFileStub, 0, 1, "code_verifier.txt");
-      assertSpyCallArg(writeTextFileStub, 0, 2, codeVerifier);
+      assertSpyCalls(mockWriteTextFile, 1);
+      assertSpyCallArg(mockWriteTextFile, 0, 0, testServerUrlHash);
+      assertSpyCallArg(mockWriteTextFile, 0, 1, "code_verifier.txt");
+      assertSpyCallArg(mockWriteTextFile, 0, 2, codeVerifier);
 
-      getServerUrlHashStub.restore();
-      writeTextFileStub.restore();
+      // Check constructor call too
+      assertSpyCalls(mockGetServerUrlHash, 1);
     });
   });
 
@@ -439,68 +380,53 @@ describe("NodeOAuthClientProvider", () => {
     it("returns the code verifier when it exists", async () => {
       const codeVerifier = "test-code-verifier";
 
-      const getServerUrlHashStub = stub(
-        utils,
-        "getServerUrlHash",
-        () => testServerUrlHash,
-      );
-      const readTextFileStub = stub(
-        mcpAuth,
-        "readTextFile",
-        () => Promise.resolve(codeVerifier),
-      );
+      // Set up mock return value
+      mockReadTextFile = spy(() => Promise.resolve(codeVerifier));
+      mockDeps.readTextFile = mockReadTextFile;
 
-      const provider = new NodeOAuthClientProvider(testOptions);
+      const provider = new NodeOAuthClientProvider(testOptions, mockDeps);
       const result = await provider.codeVerifier();
 
       assertEquals(result, codeVerifier);
-      assertSpyCalls(readTextFileStub, 1);
-      assertSpyCallArg(readTextFileStub, 0, 0, testServerUrlHash);
-      assertSpyCallArg(readTextFileStub, 0, 1, "code_verifier.txt");
+      assertSpyCalls(mockReadTextFile, 1);
+      assertSpyCallArg(mockReadTextFile, 0, 0, testServerUrlHash);
+      assertSpyCallArg(mockReadTextFile, 0, 1, "code_verifier.txt");
       assertSpyCallArg(
-        readTextFileStub,
+        mockReadTextFile,
         0,
         2,
         "No code verifier saved for session",
       );
 
-      getServerUrlHashStub.restore();
-      readTextFileStub.restore();
+      // Check constructor call too
+      assertSpyCalls(mockGetServerUrlHash, 1);
     });
 
     it("throws an error when the code verifier doesn't exist", async () => {
-      const getServerUrlHashStub = stub(
-        utils,
-        "getServerUrlHash",
-        () => testServerUrlHash,
-      );
-      const readTextFileStub = stub(
-        mcpAuth,
-        "readTextFile",
-        () => {
-          throw new Error("No code verifier saved for session");
-        },
-      );
+      // Default mock throws error, so no need to change it
+      const errorMsg = "No code verifier saved for session";
+      mockReadTextFile = spy(() => Promise.reject(new Error(errorMsg)));
+      mockDeps.readTextFile = mockReadTextFile;
 
-      const provider = new NodeOAuthClientProvider(testOptions);
+      const provider = new NodeOAuthClientProvider(testOptions, mockDeps);
 
       await assertRejects(
         () => provider.codeVerifier(),
         Error,
-        "No code verifier saved for session",
+        errorMsg,
       );
 
-      assertSpyCalls(readTextFileStub, 1);
+      assertSpyCalls(mockReadTextFile, 1);
 
-      getServerUrlHashStub.restore();
-      readTextFileStub.restore();
+      // Check constructor call too
+      assertSpyCalls(mockGetServerUrlHash, 1);
     });
   });
 
-  // Integration test to verify the full OAuth workflow
-  describe("integration", () => {
-    it("performs full OAuth workflow correctly", async () => {
-      // Setup client info, tokens, and code verifier
+  // Integration test simulation using mocks
+  describe("integration simulation", () => {
+    it("performs full OAuth workflow correctly using mocks", async () => {
+      // Setup specific mock returns if needed, otherwise defaults are used
       const clientInfo: OAuthClientInformationFull = {
         client_id: "test-client-id",
         redirect_uris: ["http://localhost:3000/callback"],
@@ -508,41 +434,17 @@ describe("NodeOAuthClientProvider", () => {
         client_id_issued_at: 123456789,
         client_secret_expires_at: 0,
       };
-
       const tokens: OAuthTokens = {
         access_token: "test-access-token",
         token_type: "Bearer",
         refresh_token: "test-refresh-token",
         expires_in: 3600,
       };
-
       const codeVerifier = "test-code-verifier";
 
-      // Set up stubs
-      const getServerUrlHashStub = stub(
-        utils,
-        "getServerUrlHash",
-        () => testServerUrlHash,
-      );
-      const writeJsonFileStub = stub(
-        mcpAuth,
-        "writeJsonFile",
-        () => Promise.resolve(),
-      );
-      const writeTextFileStub = stub(
-        mcpAuth,
-        "writeTextFile",
-        () => Promise.resolve(),
-      );
-      const openStub = stub(
-        openModule,
-        "default" as keyof typeof openModule,
-        () => Promise.resolve(),
-      );
+      const provider = new NodeOAuthClientProvider(testOptions, mockDeps);
 
-      const provider = new NodeOAuthClientProvider(testOptions);
-
-      // Execute workflow
+      // Execute workflow steps
       await provider.saveClientInformation(clientInfo);
       await provider.saveTokens(tokens);
       await provider.saveCodeVerifier(codeVerifier);
@@ -553,16 +455,15 @@ describe("NodeOAuthClientProvider", () => {
       );
       await provider.redirectToAuthorization(authUrl);
 
-      // Verify calls were made
-      assertSpyCalls(writeJsonFileStub, 2); // client info and tokens
-      assertSpyCalls(writeTextFileStub, 1); // code verifier
-      assertSpyCalls(openStub, 1); // browser open
-
-      // Restore all stubs
-      getServerUrlHashStub.restore();
-      writeJsonFileStub.restore();
-      writeTextFileStub.restore();
-      openStub.restore();
+      // Verify mock calls
+      assertSpyCalls(mockGetServerUrlHash, 1); // Constructor
+      assertSpyCalls(mockWriteJsonFile, 2); // client info and tokens
+      assertSpyCallArg(mockWriteJsonFile, 0, 2, clientInfo);
+      assertSpyCallArg(mockWriteJsonFile, 1, 2, tokens);
+      assertSpyCalls(mockWriteTextFile, 1); // code verifier
+      assertSpyCallArg(mockWriteTextFile, 0, 2, codeVerifier);
+      assertSpyCalls(mockLog, 2); // Redirect log
+      assertSpyCalls(mockOpen, 1); // browser open
     });
   });
 });

--- a/tests/node-oauth-client-provider_test.ts
+++ b/tests/node-oauth-client-provider_test.ts
@@ -1,0 +1,400 @@
+import { assertEquals, assertRejects } from "std/assert/mod.ts";
+import { afterEach, beforeEach, describe, it } from "std/testing/bdd.ts";
+import { assertSpyCalls, assertSpyCallArg, spy, stub } from "std/testing/mock.ts";
+import { NodeOAuthClientProvider } from "../src/lib/node-oauth-client-provider.ts";
+import * as mcpAuth from "../src/lib/mcp-auth-config.ts";
+import * as utils from "../src/lib/utils.ts";
+import openModule from "../src/lib/deno-open.ts";
+import { OAuthClientInformationSchema, OAuthTokensSchema } from "@modelcontextprotocol/sdk/shared/auth.js";
+import type { OAuthClientInformationFull, OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js";
+
+// Helper function to check if a string contains a substring
+function stringContaining(expected: string) {
+  return {
+    asymmetricMatch: (actual: string) => {
+      return typeof actual === 'string' && actual.includes(expected);
+    },
+    toString: () => `StringContaining(${expected})`,
+  };
+}
+
+describe("NodeOAuthClientProvider", () => {
+  const testServerUrl = "https://test-server.example.com";
+  const testServerUrlHash = "0123456789abcdef0123456789abcdef";
+  const testCallbackPort = 3000;
+  const testOptions = {
+    serverUrl: testServerUrl,
+    callbackPort: testCallbackPort,
+    callbackPath: "/test/callback",
+    clientName: "Test Client",
+    clientUri: "https://test-client.example.com",
+    softwareId: "test-software-id",
+    softwareVersion: "1.0.0",
+  };
+
+  beforeEach(() => {
+    // Add any setup needed for each test
+  });
+
+  afterEach(() => {
+    // Clean up after each test
+  });
+
+  describe("constructor", () => {
+    it("initializes with provided options", () => {
+      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
+
+      const provider = new NodeOAuthClientProvider(testOptions);
+
+      assertEquals(provider.options, testOptions);
+      assertSpyCalls(getServerUrlHashStub, 1);
+      assertSpyCallArg(getServerUrlHashStub, 0, 0, testServerUrl);
+
+      getServerUrlHashStub.restore();
+    });
+
+    it("uses default values for optional parameters", () => {
+      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
+
+      const provider = new NodeOAuthClientProvider({
+        serverUrl: testServerUrl,
+        callbackPort: testCallbackPort,
+      });
+
+      assertEquals(provider.options.serverUrl, testServerUrl);
+      assertEquals(provider.options.callbackPort, testCallbackPort);
+      // biome-ignore lint/complexity/useLiteralKeys: accessing private property for testing
+      assertEquals(provider["callbackPath"], "/oauth/callback"); // Default value
+      // biome-ignore lint/complexity/useLiteralKeys: accessing private property for testing
+      assertEquals(provider["clientName"], "MCP CLI Client"); // Default value
+      // biome-ignore lint/complexity/useLiteralKeys: accessing private property for testing
+      assertEquals(provider["clientUri"], "https://github.com/modelcontextprotocol/mcp-cli"); // Default value
+      // biome-ignore lint/complexity/useLiteralKeys: accessing private property for testing
+      assertEquals(provider["softwareId"], "2e6dc280-f3c3-4e01-99a7-8181dbd1d23d"); // Default value
+      // biome-ignore lint/complexity/useLiteralKeys: accessing private property for testing
+      assertEquals(provider["softwareVersion"], utils.MCP_REMOTE_VERSION); // Default value
+
+      getServerUrlHashStub.restore();
+    });
+  });
+
+  describe("getters", () => {
+    it("returns correct redirectUrl", () => {
+      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
+
+      const provider = new NodeOAuthClientProvider(testOptions);
+      assertEquals(provider.redirectUrl, `http://127.0.0.1:${testCallbackPort}${testOptions.callbackPath}`);
+
+      getServerUrlHashStub.restore();
+    });
+
+    it("returns correct clientMetadata", () => {
+      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
+
+      const provider = new NodeOAuthClientProvider(testOptions);
+
+      const expectedMetadata = {
+        redirect_uris: [`http://127.0.0.1:${testCallbackPort}${testOptions.callbackPath}`],
+        token_endpoint_auth_method: "none",
+        grant_types: ["authorization_code", "refresh_token"],
+        response_types: ["code"],
+        client_name: testOptions.clientName,
+        client_uri: testOptions.clientUri,
+        software_id: testOptions.softwareId,
+        software_version: testOptions.softwareVersion,
+      };
+
+      assertEquals(provider.clientMetadata, expectedMetadata);
+
+      getServerUrlHashStub.restore();
+    });
+  });
+
+  describe("clientInformation", () => {
+    it("returns client information when it exists", async () => {
+      const mockClientInfo = {
+        client_id: "test-client-id",
+        redirect_uris: ["http://localhost:3000/callback"]
+      };
+
+      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
+      const readJsonFileStub = stub(mcpAuth, "readJsonFile", () => Promise.resolve(mockClientInfo));
+
+      const provider = new NodeOAuthClientProvider(testOptions);
+      const result = await provider.clientInformation();
+
+      assertEquals(result, mockClientInfo);
+      assertSpyCalls(readJsonFileStub, 1);
+      assertSpyCallArg(readJsonFileStub, 0, 0, testServerUrlHash);
+      assertSpyCallArg(readJsonFileStub, 0, 1, "client_info.json");
+      assertSpyCallArg(readJsonFileStub, 0, 2, OAuthClientInformationSchema);
+
+      getServerUrlHashStub.restore();
+      readJsonFileStub.restore();
+    });
+
+    it("returns undefined when client information doesn't exist", async () => {
+      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
+      const readJsonFileStub = stub(mcpAuth, "readJsonFile", () => Promise.resolve(undefined));
+
+      const provider = new NodeOAuthClientProvider(testOptions);
+      const result = await provider.clientInformation();
+
+      assertEquals(result, undefined);
+      assertSpyCalls(readJsonFileStub, 1);
+
+      getServerUrlHashStub.restore();
+      readJsonFileStub.restore();
+    });
+  });
+
+  describe("saveClientInformation", () => {
+    it("saves client information", async () => {
+      const mockClientInfo: OAuthClientInformationFull = {
+        client_id: "test-client-id",
+        redirect_uris: ["http://localhost:3000/callback"],
+        client_secret: "test-secret",
+        client_id_issued_at: 123456789,
+        client_secret_expires_at: 0
+      };
+
+      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
+      const writeJsonFileStub = stub(mcpAuth, "writeJsonFile", () => Promise.resolve());
+
+      const provider = new NodeOAuthClientProvider(testOptions);
+      await provider.saveClientInformation(mockClientInfo);
+
+      assertSpyCalls(writeJsonFileStub, 1);
+      assertSpyCallArg(writeJsonFileStub, 0, 0, testServerUrlHash);
+      assertSpyCallArg(writeJsonFileStub, 0, 1, "client_info.json");
+      assertSpyCallArg(writeJsonFileStub, 0, 2, mockClientInfo);
+
+      getServerUrlHashStub.restore();
+      writeJsonFileStub.restore();
+    });
+  });
+
+  describe("tokens", () => {
+    it("returns tokens when they exist", async () => {
+      const mockTokens: OAuthTokens = {
+        access_token: "test-access-token",
+        token_type: "Bearer",
+        refresh_token: "test-refresh-token",
+        expires_in: 3600
+      };
+
+      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
+      const readJsonFileStub = stub(mcpAuth, "readJsonFile", () => Promise.resolve(mockTokens));
+
+      const provider = new NodeOAuthClientProvider(testOptions);
+      const result = await provider.tokens();
+
+      assertEquals(result, mockTokens);
+      assertSpyCalls(readJsonFileStub, 1);
+      assertSpyCallArg(readJsonFileStub, 0, 0, testServerUrlHash);
+      assertSpyCallArg(readJsonFileStub, 0, 1, "tokens.json");
+      assertSpyCallArg(readJsonFileStub, 0, 2, OAuthTokensSchema);
+
+      getServerUrlHashStub.restore();
+      readJsonFileStub.restore();
+    });
+
+    it("returns undefined when tokens don't exist", async () => {
+      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
+      const readJsonFileStub = stub(mcpAuth, "readJsonFile", () => Promise.resolve(undefined));
+
+      const provider = new NodeOAuthClientProvider(testOptions);
+      const result = await provider.tokens();
+
+      assertEquals(result, undefined);
+      assertSpyCalls(readJsonFileStub, 1);
+
+      getServerUrlHashStub.restore();
+      readJsonFileStub.restore();
+    });
+  });
+
+  describe("saveTokens", () => {
+    it("saves tokens", async () => {
+      const mockTokens: OAuthTokens = {
+        access_token: "test-access-token",
+        token_type: "Bearer",
+        refresh_token: "test-refresh-token",
+        expires_in: 3600
+      };
+
+      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
+      const writeJsonFileStub = stub(mcpAuth, "writeJsonFile", () => Promise.resolve());
+
+      const provider = new NodeOAuthClientProvider(testOptions);
+      await provider.saveTokens(mockTokens);
+
+      assertSpyCalls(writeJsonFileStub, 1);
+      assertSpyCallArg(writeJsonFileStub, 0, 0, testServerUrlHash);
+      assertSpyCallArg(writeJsonFileStub, 0, 1, "tokens.json");
+      assertSpyCallArg(writeJsonFileStub, 0, 2, mockTokens);
+
+      getServerUrlHashStub.restore();
+      writeJsonFileStub.restore();
+    });
+  });
+
+  describe("redirectToAuthorization", () => {
+    it("logs the authorization URL and opens browser successfully", async () => {
+      const authUrl = new URL("https://auth.example.com/authorize?client_id=test");
+
+      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
+      const logSpy = spy(utils, "log");
+      const openStub = stub(openModule, "default" as keyof typeof openModule, () => Promise.resolve());
+
+      const provider = new NodeOAuthClientProvider(testOptions);
+      await provider.redirectToAuthorization(authUrl);
+
+      assertSpyCalls(logSpy, 2);
+      assertSpyCallArg(logSpy, 0, 0, stringContaining("Please authorize this client by visiting:"));
+      assertSpyCallArg(logSpy, 1, 0, "Browser opened automatically.");
+
+      assertSpyCalls(openStub, 1);
+      assertSpyCallArg(openStub, 0, 0, authUrl.toString());
+
+      getServerUrlHashStub.restore();
+      logSpy.restore();
+      openStub.restore();
+    });
+
+    it("logs a fallback message when browser can't be opened", async () => {
+      const authUrl = new URL("https://auth.example.com/authorize?client_id=test");
+
+      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
+      const logSpy = spy(utils, "log");
+      const openStub = stub(openModule, "default" as keyof typeof openModule, () => { throw new Error("Failed to open browser"); });
+
+      const provider = new NodeOAuthClientProvider(testOptions);
+      await provider.redirectToAuthorization(authUrl);
+
+      assertSpyCalls(logSpy, 2);
+      assertSpyCallArg(logSpy, 0, 0, stringContaining("Please authorize this client by visiting:"));
+      assertSpyCallArg(logSpy, 1, 0, "Could not open browser automatically. Please copy and paste the URL above into your browser.");
+
+      assertSpyCalls(openStub, 1);
+
+      getServerUrlHashStub.restore();
+      logSpy.restore();
+      openStub.restore();
+    });
+  });
+
+  describe("saveCodeVerifier", () => {
+    it("saves the code verifier", async () => {
+      const codeVerifier = "test-code-verifier";
+
+      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
+      const writeTextFileStub = stub(mcpAuth, "writeTextFile", () => Promise.resolve());
+
+      const provider = new NodeOAuthClientProvider(testOptions);
+      await provider.saveCodeVerifier(codeVerifier);
+
+      assertSpyCalls(writeTextFileStub, 1);
+      assertSpyCallArg(writeTextFileStub, 0, 0, testServerUrlHash);
+      assertSpyCallArg(writeTextFileStub, 0, 1, "code_verifier.txt");
+      assertSpyCallArg(writeTextFileStub, 0, 2, codeVerifier);
+
+      getServerUrlHashStub.restore();
+      writeTextFileStub.restore();
+    });
+  });
+
+  describe("codeVerifier", () => {
+    it("returns the code verifier when it exists", async () => {
+      const codeVerifier = "test-code-verifier";
+
+      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
+      const readTextFileStub = stub(mcpAuth, "readTextFile", () => Promise.resolve(codeVerifier));
+
+      const provider = new NodeOAuthClientProvider(testOptions);
+      const result = await provider.codeVerifier();
+
+      assertEquals(result, codeVerifier);
+      assertSpyCalls(readTextFileStub, 1);
+      assertSpyCallArg(readTextFileStub, 0, 0, testServerUrlHash);
+      assertSpyCallArg(readTextFileStub, 0, 1, "code_verifier.txt");
+      assertSpyCallArg(readTextFileStub, 0, 2, "No code verifier saved for session");
+
+      getServerUrlHashStub.restore();
+      readTextFileStub.restore();
+    });
+
+    it("throws an error when the code verifier doesn't exist", async () => {
+      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
+      const readTextFileStub = stub(
+        mcpAuth,
+        "readTextFile",
+        () => { throw new Error("No code verifier saved for session"); }
+      );
+
+      const provider = new NodeOAuthClientProvider(testOptions);
+
+      await assertRejects(
+        () => provider.codeVerifier(),
+        Error,
+        "No code verifier saved for session"
+      );
+
+      assertSpyCalls(readTextFileStub, 1);
+
+      getServerUrlHashStub.restore();
+      readTextFileStub.restore();
+    });
+  });
+
+  // Integration test to verify the full OAuth workflow
+  describe("integration", () => {
+    it("performs full OAuth workflow correctly", async () => {
+      // Setup client info, tokens, and code verifier
+      const clientInfo: OAuthClientInformationFull = {
+        client_id: "test-client-id",
+        redirect_uris: ["http://localhost:3000/callback"],
+        client_secret: "test-secret",
+        client_id_issued_at: 123456789,
+        client_secret_expires_at: 0
+      };
+
+      const tokens: OAuthTokens = {
+        access_token: "test-access-token",
+        token_type: "Bearer",
+        refresh_token: "test-refresh-token",
+        expires_in: 3600
+      };
+
+      const codeVerifier = "test-code-verifier";
+
+      // Set up stubs
+      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
+      const writeJsonFileStub = stub(mcpAuth, "writeJsonFile", () => Promise.resolve());
+      const writeTextFileStub = stub(mcpAuth, "writeTextFile", () => Promise.resolve());
+      const openStub = stub(openModule, "default" as keyof typeof openModule, () => Promise.resolve());
+
+      const provider = new NodeOAuthClientProvider(testOptions);
+
+      // Execute workflow
+      await provider.saveClientInformation(clientInfo);
+      await provider.saveTokens(tokens);
+      await provider.saveCodeVerifier(codeVerifier);
+
+      // Test redirect to authorization
+      const authUrl = new URL("https://auth.example.com/authorize?client_id=test");
+      await provider.redirectToAuthorization(authUrl);
+
+      // Verify calls were made
+      assertSpyCalls(writeJsonFileStub, 2); // client info and tokens
+      assertSpyCalls(writeTextFileStub, 1); // code verifier
+      assertSpyCalls(openStub, 1); // browser open
+
+      // Restore all stubs
+      getServerUrlHashStub.restore();
+      writeJsonFileStub.restore();
+      writeTextFileStub.restore();
+      openStub.restore();
+    });
+  });
+});

--- a/tests/node-oauth-client-provider_test.ts
+++ b/tests/node-oauth-client-provider_test.ts
@@ -1,18 +1,29 @@
 import { assertEquals, assertRejects } from "std/assert/mod.ts";
 import { afterEach, beforeEach, describe, it } from "std/testing/bdd.ts";
-import { assertSpyCalls, assertSpyCallArg, spy, stub } from "std/testing/mock.ts";
+import {
+  assertSpyCallArg,
+  assertSpyCalls,
+  spy,
+  stub,
+} from "std/testing/mock.ts";
 import { NodeOAuthClientProvider } from "../src/lib/node-oauth-client-provider.ts";
 import * as mcpAuth from "../src/lib/mcp-auth-config.ts";
 import * as utils from "../src/lib/utils.ts";
 import openModule from "../src/lib/deno-open.ts";
-import { OAuthClientInformationSchema, OAuthTokensSchema } from "@modelcontextprotocol/sdk/shared/auth.js";
-import type { OAuthClientInformationFull, OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js";
+import {
+  OAuthClientInformationSchema,
+  OAuthTokensSchema,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+import type {
+  OAuthClientInformationFull,
+  OAuthTokens,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
 
 // Helper function to check if a string contains a substring
 function stringContaining(expected: string) {
   return {
     asymmetricMatch: (actual: string) => {
-      return typeof actual === 'string' && actual.includes(expected);
+      return typeof actual === "string" && actual.includes(expected);
     },
     toString: () => `StringContaining(${expected})`,
   };
@@ -42,7 +53,11 @@ describe("NodeOAuthClientProvider", () => {
 
   describe("constructor", () => {
     it("initializes with provided options", () => {
-      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
+      const getServerUrlHashStub = stub(
+        utils,
+        "getServerUrlHash",
+        () => testServerUrlHash,
+      );
 
       const provider = new NodeOAuthClientProvider(testOptions);
 
@@ -54,7 +69,11 @@ describe("NodeOAuthClientProvider", () => {
     });
 
     it("uses default values for optional parameters", () => {
-      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
+      const getServerUrlHashStub = stub(
+        utils,
+        "getServerUrlHash",
+        () => testServerUrlHash,
+      );
 
       const provider = new NodeOAuthClientProvider({
         serverUrl: testServerUrl,
@@ -68,9 +87,15 @@ describe("NodeOAuthClientProvider", () => {
       // biome-ignore lint/complexity/useLiteralKeys: accessing private property for testing
       assertEquals(provider["clientName"], "MCP CLI Client"); // Default value
       // biome-ignore lint/complexity/useLiteralKeys: accessing private property for testing
-      assertEquals(provider["clientUri"], "https://github.com/modelcontextprotocol/mcp-cli"); // Default value
+      assertEquals(
+        provider["clientUri"],
+        "https://github.com/modelcontextprotocol/mcp-cli",
+      ); // Default value
       // biome-ignore lint/complexity/useLiteralKeys: accessing private property for testing
-      assertEquals(provider["softwareId"], "2e6dc280-f3c3-4e01-99a7-8181dbd1d23d"); // Default value
+      assertEquals(
+        provider["softwareId"],
+        "2e6dc280-f3c3-4e01-99a7-8181dbd1d23d",
+      ); // Default value
       // biome-ignore lint/complexity/useLiteralKeys: accessing private property for testing
       assertEquals(provider["softwareVersion"], utils.MCP_REMOTE_VERSION); // Default value
 
@@ -80,21 +105,34 @@ describe("NodeOAuthClientProvider", () => {
 
   describe("getters", () => {
     it("returns correct redirectUrl", () => {
-      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
+      const getServerUrlHashStub = stub(
+        utils,
+        "getServerUrlHash",
+        () => testServerUrlHash,
+      );
 
       const provider = new NodeOAuthClientProvider(testOptions);
-      assertEquals(provider.redirectUrl, `http://127.0.0.1:${testCallbackPort}${testOptions.callbackPath}`);
+      assertEquals(
+        provider.redirectUrl,
+        `http://127.0.0.1:${testCallbackPort}${testOptions.callbackPath}`,
+      );
 
       getServerUrlHashStub.restore();
     });
 
     it("returns correct clientMetadata", () => {
-      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
+      const getServerUrlHashStub = stub(
+        utils,
+        "getServerUrlHash",
+        () => testServerUrlHash,
+      );
 
       const provider = new NodeOAuthClientProvider(testOptions);
 
       const expectedMetadata = {
-        redirect_uris: [`http://127.0.0.1:${testCallbackPort}${testOptions.callbackPath}`],
+        redirect_uris: [
+          `http://127.0.0.1:${testCallbackPort}${testOptions.callbackPath}`,
+        ],
         token_endpoint_auth_method: "none",
         grant_types: ["authorization_code", "refresh_token"],
         response_types: ["code"],
@@ -114,11 +152,19 @@ describe("NodeOAuthClientProvider", () => {
     it("returns client information when it exists", async () => {
       const mockClientInfo = {
         client_id: "test-client-id",
-        redirect_uris: ["http://localhost:3000/callback"]
+        redirect_uris: ["http://localhost:3000/callback"],
       };
 
-      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
-      const readJsonFileStub = stub(mcpAuth, "readJsonFile", () => Promise.resolve(mockClientInfo));
+      const getServerUrlHashStub = stub(
+        utils,
+        "getServerUrlHash",
+        () => testServerUrlHash,
+      );
+      const readJsonFileStub = stub(
+        mcpAuth,
+        "readJsonFile",
+        () => Promise.resolve(mockClientInfo),
+      );
 
       const provider = new NodeOAuthClientProvider(testOptions);
       const result = await provider.clientInformation();
@@ -134,8 +180,16 @@ describe("NodeOAuthClientProvider", () => {
     });
 
     it("returns undefined when client information doesn't exist", async () => {
-      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
-      const readJsonFileStub = stub(mcpAuth, "readJsonFile", () => Promise.resolve(undefined));
+      const getServerUrlHashStub = stub(
+        utils,
+        "getServerUrlHash",
+        () => testServerUrlHash,
+      );
+      const readJsonFileStub = stub(
+        mcpAuth,
+        "readJsonFile",
+        () => Promise.resolve(undefined),
+      );
 
       const provider = new NodeOAuthClientProvider(testOptions);
       const result = await provider.clientInformation();
@@ -155,11 +209,19 @@ describe("NodeOAuthClientProvider", () => {
         redirect_uris: ["http://localhost:3000/callback"],
         client_secret: "test-secret",
         client_id_issued_at: 123456789,
-        client_secret_expires_at: 0
+        client_secret_expires_at: 0,
       };
 
-      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
-      const writeJsonFileStub = stub(mcpAuth, "writeJsonFile", () => Promise.resolve());
+      const getServerUrlHashStub = stub(
+        utils,
+        "getServerUrlHash",
+        () => testServerUrlHash,
+      );
+      const writeJsonFileStub = stub(
+        mcpAuth,
+        "writeJsonFile",
+        () => Promise.resolve(),
+      );
 
       const provider = new NodeOAuthClientProvider(testOptions);
       await provider.saveClientInformation(mockClientInfo);
@@ -180,11 +242,19 @@ describe("NodeOAuthClientProvider", () => {
         access_token: "test-access-token",
         token_type: "Bearer",
         refresh_token: "test-refresh-token",
-        expires_in: 3600
+        expires_in: 3600,
       };
 
-      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
-      const readJsonFileStub = stub(mcpAuth, "readJsonFile", () => Promise.resolve(mockTokens));
+      const getServerUrlHashStub = stub(
+        utils,
+        "getServerUrlHash",
+        () => testServerUrlHash,
+      );
+      const readJsonFileStub = stub(
+        mcpAuth,
+        "readJsonFile",
+        () => Promise.resolve(mockTokens),
+      );
 
       const provider = new NodeOAuthClientProvider(testOptions);
       const result = await provider.tokens();
@@ -200,8 +270,16 @@ describe("NodeOAuthClientProvider", () => {
     });
 
     it("returns undefined when tokens don't exist", async () => {
-      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
-      const readJsonFileStub = stub(mcpAuth, "readJsonFile", () => Promise.resolve(undefined));
+      const getServerUrlHashStub = stub(
+        utils,
+        "getServerUrlHash",
+        () => testServerUrlHash,
+      );
+      const readJsonFileStub = stub(
+        mcpAuth,
+        "readJsonFile",
+        () => Promise.resolve(undefined),
+      );
 
       const provider = new NodeOAuthClientProvider(testOptions);
       const result = await provider.tokens();
@@ -220,11 +298,19 @@ describe("NodeOAuthClientProvider", () => {
         access_token: "test-access-token",
         token_type: "Bearer",
         refresh_token: "test-refresh-token",
-        expires_in: 3600
+        expires_in: 3600,
       };
 
-      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
-      const writeJsonFileStub = stub(mcpAuth, "writeJsonFile", () => Promise.resolve());
+      const getServerUrlHashStub = stub(
+        utils,
+        "getServerUrlHash",
+        () => testServerUrlHash,
+      );
+      const writeJsonFileStub = stub(
+        mcpAuth,
+        "writeJsonFile",
+        () => Promise.resolve(),
+      );
 
       const provider = new NodeOAuthClientProvider(testOptions);
       await provider.saveTokens(mockTokens);
@@ -241,17 +327,32 @@ describe("NodeOAuthClientProvider", () => {
 
   describe("redirectToAuthorization", () => {
     it("logs the authorization URL and opens browser successfully", async () => {
-      const authUrl = new URL("https://auth.example.com/authorize?client_id=test");
+      const authUrl = new URL(
+        "https://auth.example.com/authorize?client_id=test",
+      );
 
-      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
+      const getServerUrlHashStub = stub(
+        utils,
+        "getServerUrlHash",
+        () => testServerUrlHash,
+      );
       const logSpy = spy(utils, "log");
-      const openStub = stub(openModule, "default" as keyof typeof openModule, () => Promise.resolve());
+      const openStub = stub(
+        openModule,
+        "default" as keyof typeof openModule,
+        () => Promise.resolve(),
+      );
 
       const provider = new NodeOAuthClientProvider(testOptions);
       await provider.redirectToAuthorization(authUrl);
 
       assertSpyCalls(logSpy, 2);
-      assertSpyCallArg(logSpy, 0, 0, stringContaining("Please authorize this client by visiting:"));
+      assertSpyCallArg(
+        logSpy,
+        0,
+        0,
+        stringContaining("Please authorize this client by visiting:"),
+      );
       assertSpyCallArg(logSpy, 1, 0, "Browser opened automatically.");
 
       assertSpyCalls(openStub, 1);
@@ -263,18 +364,40 @@ describe("NodeOAuthClientProvider", () => {
     });
 
     it("logs a fallback message when browser can't be opened", async () => {
-      const authUrl = new URL("https://auth.example.com/authorize?client_id=test");
+      const authUrl = new URL(
+        "https://auth.example.com/authorize?client_id=test",
+      );
 
-      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
+      const getServerUrlHashStub = stub(
+        utils,
+        "getServerUrlHash",
+        () => testServerUrlHash,
+      );
       const logSpy = spy(utils, "log");
-      const openStub = stub(openModule, "default" as keyof typeof openModule, () => { throw new Error("Failed to open browser"); });
+      const openStub = stub(
+        openModule,
+        "default" as keyof typeof openModule,
+        () => {
+          throw new Error("Failed to open browser");
+        },
+      );
 
       const provider = new NodeOAuthClientProvider(testOptions);
       await provider.redirectToAuthorization(authUrl);
 
       assertSpyCalls(logSpy, 2);
-      assertSpyCallArg(logSpy, 0, 0, stringContaining("Please authorize this client by visiting:"));
-      assertSpyCallArg(logSpy, 1, 0, "Could not open browser automatically. Please copy and paste the URL above into your browser.");
+      assertSpyCallArg(
+        logSpy,
+        0,
+        0,
+        stringContaining("Please authorize this client by visiting:"),
+      );
+      assertSpyCallArg(
+        logSpy,
+        1,
+        0,
+        "Could not open browser automatically. Please copy and paste the URL above into your browser.",
+      );
 
       assertSpyCalls(openStub, 1);
 
@@ -288,8 +411,16 @@ describe("NodeOAuthClientProvider", () => {
     it("saves the code verifier", async () => {
       const codeVerifier = "test-code-verifier";
 
-      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
-      const writeTextFileStub = stub(mcpAuth, "writeTextFile", () => Promise.resolve());
+      const getServerUrlHashStub = stub(
+        utils,
+        "getServerUrlHash",
+        () => testServerUrlHash,
+      );
+      const writeTextFileStub = stub(
+        mcpAuth,
+        "writeTextFile",
+        () => Promise.resolve(),
+      );
 
       const provider = new NodeOAuthClientProvider(testOptions);
       await provider.saveCodeVerifier(codeVerifier);
@@ -308,8 +439,16 @@ describe("NodeOAuthClientProvider", () => {
     it("returns the code verifier when it exists", async () => {
       const codeVerifier = "test-code-verifier";
 
-      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
-      const readTextFileStub = stub(mcpAuth, "readTextFile", () => Promise.resolve(codeVerifier));
+      const getServerUrlHashStub = stub(
+        utils,
+        "getServerUrlHash",
+        () => testServerUrlHash,
+      );
+      const readTextFileStub = stub(
+        mcpAuth,
+        "readTextFile",
+        () => Promise.resolve(codeVerifier),
+      );
 
       const provider = new NodeOAuthClientProvider(testOptions);
       const result = await provider.codeVerifier();
@@ -318,18 +457,29 @@ describe("NodeOAuthClientProvider", () => {
       assertSpyCalls(readTextFileStub, 1);
       assertSpyCallArg(readTextFileStub, 0, 0, testServerUrlHash);
       assertSpyCallArg(readTextFileStub, 0, 1, "code_verifier.txt");
-      assertSpyCallArg(readTextFileStub, 0, 2, "No code verifier saved for session");
+      assertSpyCallArg(
+        readTextFileStub,
+        0,
+        2,
+        "No code verifier saved for session",
+      );
 
       getServerUrlHashStub.restore();
       readTextFileStub.restore();
     });
 
     it("throws an error when the code verifier doesn't exist", async () => {
-      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
+      const getServerUrlHashStub = stub(
+        utils,
+        "getServerUrlHash",
+        () => testServerUrlHash,
+      );
       const readTextFileStub = stub(
         mcpAuth,
         "readTextFile",
-        () => { throw new Error("No code verifier saved for session"); }
+        () => {
+          throw new Error("No code verifier saved for session");
+        },
       );
 
       const provider = new NodeOAuthClientProvider(testOptions);
@@ -337,7 +487,7 @@ describe("NodeOAuthClientProvider", () => {
       await assertRejects(
         () => provider.codeVerifier(),
         Error,
-        "No code verifier saved for session"
+        "No code verifier saved for session",
       );
 
       assertSpyCalls(readTextFileStub, 1);
@@ -356,23 +506,39 @@ describe("NodeOAuthClientProvider", () => {
         redirect_uris: ["http://localhost:3000/callback"],
         client_secret: "test-secret",
         client_id_issued_at: 123456789,
-        client_secret_expires_at: 0
+        client_secret_expires_at: 0,
       };
 
       const tokens: OAuthTokens = {
         access_token: "test-access-token",
         token_type: "Bearer",
         refresh_token: "test-refresh-token",
-        expires_in: 3600
+        expires_in: 3600,
       };
 
       const codeVerifier = "test-code-verifier";
 
       // Set up stubs
-      const getServerUrlHashStub = stub(utils, "getServerUrlHash", () => testServerUrlHash);
-      const writeJsonFileStub = stub(mcpAuth, "writeJsonFile", () => Promise.resolve());
-      const writeTextFileStub = stub(mcpAuth, "writeTextFile", () => Promise.resolve());
-      const openStub = stub(openModule, "default" as keyof typeof openModule, () => Promise.resolve());
+      const getServerUrlHashStub = stub(
+        utils,
+        "getServerUrlHash",
+        () => testServerUrlHash,
+      );
+      const writeJsonFileStub = stub(
+        mcpAuth,
+        "writeJsonFile",
+        () => Promise.resolve(),
+      );
+      const writeTextFileStub = stub(
+        mcpAuth,
+        "writeTextFile",
+        () => Promise.resolve(),
+      );
+      const openStub = stub(
+        openModule,
+        "default" as keyof typeof openModule,
+        () => Promise.resolve(),
+      );
 
       const provider = new NodeOAuthClientProvider(testOptions);
 
@@ -382,7 +548,9 @@ describe("NodeOAuthClientProvider", () => {
       await provider.saveCodeVerifier(codeVerifier);
 
       // Test redirect to authorization
-      const authUrl = new URL("https://auth.example.com/authorize?client_id=test");
+      const authUrl = new URL(
+        "https://auth.example.com/authorize?client_id=test",
+      );
       await provider.redirectToAuthorization(authUrl);
 
       // Verify calls were made

--- a/tests/node-oauth-client-provider_test.ts
+++ b/tests/node-oauth-client-provider_test.ts
@@ -5,11 +5,7 @@ import {
   assertRejects,
 } from "std/assert/mod.ts";
 import { afterEach, beforeEach, describe, it } from "std/testing/bdd.ts";
-import {
-  assertSpyCallArg,
-  assertSpyCalls,
-  spy,
-} from "std/testing/mock.ts";
+import { assertSpyCallArg, assertSpyCalls, spy } from "std/testing/mock.ts";
 import type { Spy } from "std/testing/mock.ts";
 import { NodeOAuthClientProvider } from "../src/lib/node-oauth-client-provider.ts";
 import {


### PR DESCRIPTION
This commit introduces a comprehensive test suite for the NodeOAuthClientProvider class, covering initialization, getters, client information handling, token management, and the full OAuth workflow. The tests utilize stubs and spies to verify interactions with utility functions and ensure correct behavior of the provider methods.